### PR TITLE
Fix the propagator that was broken in the switch to cycles

### DIFF
--- a/matterwave/split_step.py
+++ b/matterwave/split_step.py
@@ -1,5 +1,5 @@
 import numpy as np
-from scipy.constants import hbar, h
+from scipy.constants import hbar
 from typing import Callable, Union, Any
 
 from .wf_tools import normalize


### PR DESCRIPTION
In the original switch from radians to cycles [c6b2244](https://github.com/QSTheory/matterwave/commit/c6b2244ddb64572b573003de9c7ceed0e5c28a35) only the `hbar` was changed to `h` in the computation of `factor` in the `propagate` method. But the frequencies always appear quadratic so an additional factor of `2*np.pi` was missing.