### PR TITLE
Remove doc-strings in __init__.py

### DIFF
--- a/src/matterwave/__init__.py
+++ b/src/matterwave/__init__.py
@@ -1,25 +1,4 @@
-"""
-.. rubric:: The objects inside the tables can be imported directly from :py:mod:`matterwave`:
 
-.. autosummary::
-   :nosignatures:
-
-   expectation_value
-   get_e_kin
-   get_ground_state_ho
-   norm
-   normalize
-   propagate
-   split_step
-
-Example:
-
-.. code-block:: python
-
-	>>> from matterwave import split_step
-	>>> from matterwave import normalize
-
-"""
 from ._src.split_step import (
    propagate as propagate,
    split_step as split_step,


### PR DESCRIPTION
Stacked PRs:
 * __->__#36
 * #35
 * #37


--- --- ---

### Remove doc-strings in __init__.py


Not up to date and not really necessary.
