### PR TITLE
Update pip CI workflow to use Python 3.12

### DIFF
--- a/.github/workflows/pip_test.yml
+++ b/.github/workflows/pip_test.yml
@@ -19,10 +19,10 @@ jobs:
       with:
         fetch-depth: 0
         fetch-tags: true
-    - name: Set up Python 3.10
+    - name: Set up Python 3.12
       uses: actions/setup-python@v5
       with:
-        python-version: "3.10"
+        python-version: "3.12"
     - name: Setup SSH
       uses: webfactory/ssh-agent@v0.8.0
       with:


### PR DESCRIPTION
Stacked PRs:
 * #36
 * #35
 * __->__#37


--- --- ---

### Update pip CI workflow to use Python 3.12


3.11 would requrie array-api-strict<2.4.
