### PR TITLE
Rename parameter `m` to `mass` in `get_e_kin`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Best viewed [here](https://qstheory.github.io/matterwave/main/changelog.html).
 
 ## matterwave 0.5.1 (unreleased)
 - `get_ground_state_ho` has now a `device` argument to control on which device the `Array` is created.
+- Rename parameter `m` to `mass` in `get_e_kin` in order to be more consistent with the other functions.
 
 ## matterwave 0.5.0 (17 July 2025)
 - Initial public release.

--- a/src/matterwave/_src/wf_tools.py
+++ b/src/matterwave/_src/wf_tools.py
@@ -47,14 +47,14 @@ def normalize(psi: fa.Array) -> fa.Array:
     norm_factor = psi.xp.sqrt(1./norm(psi))
     return psi * norm_factor
 
-def get_e_kin(psi: fa.Array, m: float, return_microK: bool = False):
+def get_e_kin(psi: fa.Array, mass: float, return_microK: bool = False):
     """Compute the kinetic energy of the given wave function with the given mass.
 
     Parameters
     ----------
     psi : fa.Array
         The wave function.
-    m : float
+    mass : float
         The mass of the wave function.
     return_microK : bool, optional
         Return the kinetic energy in microK instead of Joule.
@@ -72,7 +72,7 @@ def get_e_kin(psi: fa.Array, m: float, return_microK: bool = False):
     # Move hbar**2/(2*m) until after accumulation to allow accumulation also in fp32.
     # Otherwise the individual values typically underflow to zero.
     kin_op = reduce(lambda a,b: a+b, [(2*np.pi*fa.coords_from_arr(psi, dim.name, "freq"))**2. for dim in psi.dims])
-    post_factor = hbar**2/(2*m)
+    post_factor = hbar**2/(2*mass)
     if return_microK:
         post_factor /= (Boltzmann * 1e-6)
     return expectation_value(psi, kin_op) * post_factor

--- a/tests/end_to_end/test_physics.py
+++ b/tests/end_to_end/test_physics.py
@@ -59,7 +59,7 @@ def test_1d_x_split_step(xp: Any, precision: PrecisionSpec, eager: bool) -> None
             psi, _ = split_step_scan_iteration(psi)
 
     e_pot = expectation_value(psi, harmonic_potential_1d)
-    e_kin = get_e_kin(psi, m=mass)
+    e_kin = get_e_kin(psi, mass=mass)
 
     np.testing.assert_array_almost_equal(e_pot + e_kin, hbar*omega_x*3./2.)
 
@@ -96,7 +96,7 @@ def test_1d_split_step_imag_time(xp: Any, precision: PrecisionSpec, eager: bool)
 
     V = 0.5 * mass * omega_x**2. * x**2.
     def total_energy(psi: fa.Array) -> float:
-        E_kin = get_e_kin(psi, m=mass, return_microK=True)
+        E_kin = get_e_kin(psi, mass=mass, return_microK=True)
         E_pot = expectation_value(psi, V) / (Boltzmann * 1e-6)
         return E_kin + E_pot
 
@@ -156,7 +156,7 @@ def test_1d_set_ground_state(xp: Any, precision: PrecisionSpec, eager: bool) -> 
     V = 0.5 * mass * omega_x**2. * x**2.
     # check if ground state is normalized
     np.testing.assert_array_almost_equal(float(norm(psi)), 1)
-    E_kin = get_e_kin(psi, m=mass, return_microK=True)
+    E_kin = get_e_kin(psi, mass=mass, return_microK=True)
     E_pot = expectation_value(psi, V) / (Boltzmann * 1e-6)
     E_tot = E_kin + E_pot
     E_tot_analytical = 0.5*omega_x*hbar / (Boltzmann * 1e-6)


### PR DESCRIPTION
This is more consistent with other functions.